### PR TITLE
Add a PayPal checkout example page

### DIFF
--- a/paypal-checkout.html
+++ b/paypal-checkout.html
@@ -9,10 +9,6 @@
     <body>
         <h1>PayPal PopupBridge Example</h1>
         <div id="paypal-button-container"></div>
-        <dl>
-            <dt id="resultTerm"></dt>
-            <dd id="resultData"></dd>
-        </dl>
         <pre id="log"></pre>
     <script>
         function paymentOptions() {


### PR DESCRIPTION
This adds an example page for PayPal checkout.

The client ID is taken from the PayPal checkout interactive demo: https://developer.paypal.com/demo/checkout/#/pattern/client

After going through the PayPal flow the authorization data would spit out into the pre tag for inspection.