### PR TITLE
Update Fallback URL

### DIFF
--- a/local-payment-methods.html
+++ b/local-payment-methods.html
@@ -75,7 +75,7 @@
               amount: "10.67",
               fallback: {
                 // see Fallback section for details on these params
-                url: "https://your-domain.com/page-to-complete-checkout",
+                url: "com.braintreepayments.popupbridgeexample://popupbridgev1",
                 buttonText: "Complete Payment",
               },
               currencyCode: "EUR",


### PR DESCRIPTION
Update fallback URL for popup bridge on iOS. From our testing this is ignored on Android and the app falls back as expected. On iOS we need the fallback URL structured correctly for the URL scheme. I've tested this locally on iOS and it's now falling back to the app correctly with this change.